### PR TITLE
fix: enable optimization again

### DIFF
--- a/Sources/Makefile
+++ b/Sources/Makefile
@@ -3,7 +3,7 @@ EXE := kernel.elf
 
 TRIPLE := aarch64-none-none-elf
 SWIFTC := swiftc
-SWIFTC_FLAGS := -target $(TRIPLE) -enable-experimental-feature Embedded -wmo -Xfrontend -no-allocations -parse-as-library -swift-version 6
+SWIFTC_FLAGS := -target $(TRIPLE) -enable-experimental-feature Embedded -wmo -Osize -Xfrontend -no-allocations -parse-as-library -swift-version 6
 AS := clang -x assembler
 ASFLAGS := -target $(TRIPLE) -c
 LD := clang -fuse-ld=lld


### PR DESCRIPTION
I want to enable optimization, but a linker error occurs if I do it. `swift_release` should be in [EmbeddedRuntime](https://github.com/apple/swift/blob/main/stdlib/public/core/EmbeddedRuntime.swift).

```console
$ make
make -C Sources
make[1]: Entering directory '/home/kebo/swift_os/Sources'
clang -x assembler -target aarch64-none-none-elf -c boot.s -o boot.o
swiftc -target aarch64-none-none-elf -enable-experimental-feature Embedded -wmo -Osize -Xfrontend -no-allocations -parse-as-library -swift-version 6 -c kernel.swift -o kernel.o
clang -fuse-ld=lld -nostdlib -Wl,-gc-sections -static -Tlinker.ld boot.o kernel.o -o kernel.elf
ld.lld: error: undefined symbol: swift_release
>>> referenced by kernel.o
>>>               kernel.o:(swift_unexpectedError)
clang: error: linker command failed with exit code 1 (use -v to see invocation)
make[1]: *** [Makefile:17: kernel.elf] Error 1
make[1]: Leaving directory '/home/kebo/swift_os/Sources'
make: *** [Makefile:8: all] Error 2
```