### PR TITLE
ci: add swift-format lint job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,3 +12,9 @@ jobs:
       - uses: actions/checkout@v4
       - run: apt-get update && apt-get install --no-install-recommends -y make llvm
       - run: make
+  lint:
+    runs-on: ubuntu-latest
+    container: swiftlang/swift:nightly-main-jammy
+    steps:
+      - uses: actions/checkout@v4
+      - run: swift format lint -rs .


### PR DESCRIPTION
This repository is now using swift-format to format its source code. This pull request is adding a CI job that checks swift-format warnings.